### PR TITLE
Give example for `caller`

### DIFF
--- a/docs/funcs.rst
+++ b/docs/funcs.rst
@@ -13,7 +13,7 @@ Functions
 
 .. function:: caller(*args, **kwargs)
 
-    Returns function calling its argument with passed arguments.
+    Returns function calling its argument with passed arguments::
 
         apply_operation_to_values = caller([2,4])
         apply_operation_to_values(sum)

--- a/docs/funcs.rst
+++ b/docs/funcs.rst
@@ -15,6 +15,12 @@ Functions
 
     Returns function calling its argument with passed arguments.
 
+        apply_operation_to_values = caller([2,4])
+        apply_operation_to_values(sum)
+        # 6
+        apply_operation_to_values(math.prod)
+        # 8
+
 
 .. function:: partial(func, *args, **kwargs)
 


### PR DESCRIPTION
The function doc, while being exact, can be hard to read. Giving an example clarifies the function's behavior.